### PR TITLE
Bugfix: [smbios] memory access violation

### DIFF
--- a/smbios/baseboard.go
+++ b/smbios/baseboard.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 	"github.com/moxspec/moxspec/util"
 )
@@ -15,7 +17,11 @@ type Baseboard struct {
 	BoardType    string
 }
 
-func parseBaseboard(s *gosmbios.Structure) *Baseboard {
+func parseBaseboard(s *gosmbios.Structure) (*Baseboard, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil given")
+	}
+
 	bboard := new(Baseboard)
 
 	bboard.Manufacturer = util.ShortenVendorName(getStringsSet(s, 0x04))
@@ -25,5 +31,5 @@ func parseBaseboard(s *gosmbios.Structure) *Baseboard {
 	bboard.AssetTag = getStringsSet(s, 0x08)
 
 	log.Debugf("%+v", bboard)
-	return bboard
+	return bboard, nil
 }

--- a/smbios/bios.go
+++ b/smbios/bios.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 	"github.com/moxspec/moxspec/util"
 )
@@ -15,7 +17,11 @@ type BIOS struct {
 	Characteristics []string
 }
 
-func parseBIOS(s *gosmbios.Structure) *BIOS {
+func parseBIOS(s *gosmbios.Structure) (*BIOS, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil given")
+	}
+
 	bios := new(BIOS)
 
 	bios.Vendor = util.ShortenVendorName(getStringsSet(s, 0x04))
@@ -26,5 +32,5 @@ func parseBIOS(s *gosmbios.Structure) *BIOS {
 
 	log.Debugf("%+v", bios)
 
-	return bios
+	return bios, nil
 }

--- a/smbios/cache.go
+++ b/smbios/cache.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 )
 
@@ -22,7 +24,11 @@ type Cache struct {
 	Associativity       string
 }
 
-func parseCache(s *gosmbios.Structure) *Cache {
+func parseCache(s *gosmbios.Structure) (*Cache, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil given")
+	}
+
 	c := new(Cache)
 
 	c.SocketDesignation = getStringsSet(s, 0x04)
@@ -39,7 +45,7 @@ func parseCache(s *gosmbios.Structure) *Cache {
 
 	log.Debugf("%+v", c)
 
-	return c
+	return c, nil
 }
 
 func parseCacheConfiguration(b uint16) (opmode string, enabled bool, location string, socketed bool, level uint8) {

--- a/smbios/chassis.go
+++ b/smbios/chassis.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 	"github.com/moxspec/moxspec/util"
 )
@@ -19,7 +21,11 @@ type Chassis struct {
 	SKUNumber          string
 }
 
-func parseChassis(s *gosmbios.Structure) *Chassis {
+func parseChassis(s *gosmbios.Structure) (*Chassis, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil given")
+	}
+
 	c := new(Chassis)
 
 	c.Manufacturer = util.ShortenVendorName(getStringsSet(s, 0x04))
@@ -35,7 +41,7 @@ func parseChassis(s *gosmbios.Structure) *Chassis {
 
 	log.Debugf("%+v", c)
 
-	return c
+	return c, nil
 }
 
 func parseChassisState(b uint8) string {

--- a/smbios/memory_device.go
+++ b/smbios/memory_device.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 	"github.com/moxspec/moxspec/util"
 )
@@ -79,8 +81,12 @@ func getModuleType(typeDetail []string) string {
 	return moduleTypeString[moduleType]
 }
 
-func parseMemoryDevice(s *gosmbios.Structure) *MemoryDevice {
+func parseMemoryDevice(s *gosmbios.Structure) (*MemoryDevice, error) {
 	mem := new(MemoryDevice)
+
+	if len(s.Strings) == 0 {
+		return nil, fmt.Errorf("no data")
+	}
 
 	mem.DeviceLocator = s.Strings[0]
 	mem.TotalWidth = getWord(s, 0x08) // 0xffff == unknown
@@ -108,7 +114,7 @@ func parseMemoryDevice(s *gosmbios.Structure) *MemoryDevice {
 
 	log.Debugf("%+v", mem)
 
-	return mem
+	return mem, nil
 }
 
 func parseMemorySize(b uint16, b2 uint32) uint32 {

--- a/smbios/powersupply.go
+++ b/smbios/powersupply.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 	"github.com/moxspec/moxspec/util"
 )
@@ -20,7 +22,11 @@ type PowerSupply struct {
 	HotReplaceable   bool
 }
 
-func parsePowerSupply(s *gosmbios.Structure) *PowerSupply {
+func parsePowerSupply(s *gosmbios.Structure) (*PowerSupply, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil given")
+	}
+
 	ps := new(PowerSupply)
 
 	ps.Location = getStringsSet(s, 0x05)
@@ -36,7 +42,7 @@ func parsePowerSupply(s *gosmbios.Structure) *PowerSupply {
 
 	log.Debugf("%+v", ps)
 
-	return ps
+	return ps, nil
 }
 
 func parsePowerSupplyCap(w uint16) uint16 {

--- a/smbios/processor.go
+++ b/smbios/processor.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 	"github.com/moxspec/moxspec/util"
 )
@@ -33,7 +35,11 @@ type Processor struct {
 	ThreadCount       uint16
 }
 
-func parseProcessor(s *gosmbios.Structure) *Processor {
+func parseProcessor(s *gosmbios.Structure) (*Processor, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil given")
+	}
+
 	p := new(Processor)
 
 	p.SocketDesignation = getStringsSet(s, 0x04)
@@ -56,7 +62,7 @@ func parseProcessor(s *gosmbios.Structure) *Processor {
 
 	log.Debugf("%+v", p)
 
-	return p
+	return p, nil
 }
 
 func parseProcessorStatus(b uint8) []string {

--- a/smbios/smbios.go
+++ b/smbios/smbios.go
@@ -140,6 +140,10 @@ func (s *Spec) Decode() error {
 	log.Debugf("found smbios v%s", s.Version())
 
 	for _, tbl := range tbls {
+		if tbl == nil {
+			continue
+		}
+
 		st := new(Structure)
 
 		st.Header = new(Header)
@@ -148,41 +152,42 @@ func (s *Spec) Decode() error {
 
 		log.Debugf("type id: %x, handle id: %x", st.Header.Type, st.Header.Handle)
 
+		var err error = nil
 		switch st.Header.Type {
 		case biosInformation:
 			log.Debug("type: bios_information")
-			st.Data = parseBIOS(tbl)
+			st.Data, err = parseBIOS(tbl)
 		case systemInformation:
 			log.Debug("type: system_information")
-			st.Data = parseSystem(tbl)
+			st.Data, err = parseSystem(tbl)
 		case baseboardInformation:
 			log.Debug("type: baseboard_information")
-			st.Data = parseBaseboard(tbl)
+			st.Data, err = parseBaseboard(tbl)
 		case systemEnclosure:
 			log.Debug("type: system_enclosure")
-			st.Data = parseChassis(tbl)
+			st.Data, err = parseChassis(tbl)
 		case processorInformation:
 			log.Debug("type: processor_information")
-			st.Data = parseProcessor(tbl)
+			st.Data, err = parseProcessor(tbl)
 		case cacheInformation:
 			log.Debug("type: cache_information")
-			st.Data = parseCache(tbl)
+			st.Data, err = parseCache(tbl)
 		case memoryDevice:
 			log.Debug("type: memory_device")
-			st.Data = parseMemoryDevice(tbl)
+			st.Data, err = parseMemoryDevice(tbl)
 		case systemPowerSupply:
 			log.Debug("type: system_power_supply")
-			st.Data = parsePowerSupply(tbl)
+			st.Data, err = parsePowerSupply(tbl)
 		default:
 			log.Debug("non-supported record type")
 			continue
 		}
 
-		if st.Data != nil {
-			s.Records[st.Header.Type] = append(s.Records[st.Header.Type], st)
-		} else {
+		if err != nil {
 			log.Debug("could not decode record")
+			continue
 		}
+		s.Records[st.Header.Type] = append(s.Records[st.Header.Type], st)
 	}
 
 	return nil

--- a/smbios/system.go
+++ b/smbios/system.go
@@ -1,6 +1,8 @@
 package smbios
 
 import (
+	"fmt"
+
 	gosmbios "github.com/digitalocean/go-smbios/smbios"
 	"github.com/moxspec/moxspec/util"
 )
@@ -15,7 +17,11 @@ type System struct {
 	Family       string
 }
 
-func parseSystem(s *gosmbios.Structure) *System {
+func parseSystem(s *gosmbios.Structure) (*System, error) {
+	if s == nil {
+		return nil, fmt.Errorf("nil given")
+	}
+
 	sinfo := new(System)
 
 	sinfo.Manufacturer = util.ShortenVendorName(getStringsSet(s, 0x04))
@@ -27,5 +33,5 @@ func parseSystem(s *gosmbios.Structure) *System {
 
 	log.Debugf("%+v", sinfo)
 
-	return sinfo
+	return sinfo, nil
 }


### PR DESCRIPTION
```
[debug][smbios] type id: 11, handle id: 9
[debug][smbios] type: memory_device
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/moxspec/moxspec/smbios.parseMemoryDevice(0xc000062540, 0x6)
        /go/src/github.com/moxspec/moxspec/smbios/memory_device.go:47 +0x605
github.com/moxspec/moxspec/smbios.(*Spec).Decode(0xc00000c0e0, 0x0, 0x0)
        /go/src/github.com/moxspec/moxspec/smbios/smbios.go:172 +0xb4f
main.decode(0xc00004e1e0, 0x640780, 0xc00001a2fa, 0x5fea9c)
        /go/src/github.com/moxspec/moxspec/cmd/mox/mox.go:106 +0xfc
main.show(0xc00004e1e0, 0xc0000107e0, 0x5fea9a)
        /go/src/github.com/moxspec/moxspec/cmd/mox/show.go:14 +0x45
main.main()
        /go/src/github.com/moxspec/moxspec/cmd/mox/mox.go:81 +0x327
```