### PR TITLE
add bonding support

### DIFF
--- a/bonding/bonding.go
+++ b/bonding/bonding.go
@@ -1,0 +1,138 @@
+package bonding
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+// BondInterface represents a bonding device
+type BondInterface struct {
+	Name      string
+	Slaves    []string
+	AddrList  []netlink.Addr
+	LinkAttrs netlink.LinkAttrs
+	BondAttrs BondAttrs
+}
+
+type BondAttrs struct {
+	Mode            netlink.BondMode
+	ActiveSlave     string
+	Miimon          int
+	UpDelay         int
+	DownDelay       int
+	UseCarrier      int
+	ArpInterval     int
+	ArpIpTargets    []net.IP
+	ArpValidate     netlink.BondArpValidate
+	ArpAllTargets   netlink.BondArpAllTargets
+	Primary         string
+	PrimaryReselect netlink.BondPrimaryReselect
+	FailOverMac     netlink.BondFailOverMac
+	XmitHashPolicy  netlink.BondXmitHashPolicy
+	ResendIgmp      int
+	NumPeerNotif    int
+	AllSlavesActive int
+	MinLinks        int
+	LpInterval      int
+	PacketsPerSlave int
+	LacpRate        netlink.BondLacpRate
+	AdSelect        netlink.BondAdSelect
+	AdInfo          *netlink.BondAdInfo
+	AdActorSysPrio  int
+	AdUserPortKey   int
+	AdActorSystem   net.HardwareAddr
+	TlbDynamicLb    int
+	//MiiStatus int
+}
+
+// Decode make BondInterface satisfy the mox.Decoder interface
+func (intf *BondInterface) Decode() error {
+
+	bli, err := netlink.LinkByName(intf.Name)
+	if err != nil {
+		return err
+	}
+
+	slaves, err := findBondSlaves(bli.Attrs().Index)
+	if err != nil {
+		return err
+	}
+
+	intf.Slaves = slaves
+
+	stats, err := getBondParameters(bli)
+	if err != nil {
+		return err
+	}
+
+	if stats != nil {
+		intf.LinkAttrs = stats.LinkAttrs
+
+		intf.BondAttrs.Mode = stats.Mode
+
+		activeslave, err := netlink.LinkByIndex(stats.ActiveSlave)
+		if err == nil {
+			intf.BondAttrs.ActiveSlave = activeslave.Attrs().Name
+		}
+
+		intf.BondAttrs.Miimon = stats.Miimon
+		intf.BondAttrs.UpDelay = stats.UpDelay
+		intf.BondAttrs.DownDelay = stats.DownDelay
+		intf.BondAttrs.UseCarrier = stats.UseCarrier
+		intf.BondAttrs.ArpInterval = stats.ArpInterval
+		intf.BondAttrs.ArpIpTargets = stats.ArpIpTargets
+		intf.BondAttrs.ArpValidate = stats.ArpValidate
+		intf.BondAttrs.ArpAllTargets = stats.ArpAllTargets
+
+		primary, err := netlink.LinkByIndex(stats.Primary)
+		if err == nil {
+			intf.BondAttrs.ActiveSlave = primary.Attrs().Name
+		}
+
+		intf.BondAttrs.PrimaryReselect = stats.PrimaryReselect
+		intf.BondAttrs.FailOverMac = stats.FailOverMac
+		intf.BondAttrs.XmitHashPolicy = stats.XmitHashPolicy
+		intf.BondAttrs.ResendIgmp = stats.ResendIgmp
+		intf.BondAttrs.NumPeerNotif = stats.NumPeerNotif
+		intf.BondAttrs.AllSlavesActive = stats.AllSlavesActive
+		intf.BondAttrs.MinLinks = stats.MinLinks
+		intf.BondAttrs.LpInterval = stats.LpInterval
+		intf.BondAttrs.PacketsPerSlave = stats.PacketsPerSlave
+		intf.BondAttrs.LacpRate = stats.LacpRate
+		intf.BondAttrs.AdSelect = stats.AdSelect
+		intf.BondAttrs.AdInfo = stats.AdInfo
+		intf.BondAttrs.AdActorSysPrio = stats.AdActorSysPrio
+		intf.BondAttrs.AdUserPortKey = stats.AdUserPortKey
+		intf.BondAttrs.AdActorSystem = stats.AdActorSystem
+		intf.BondAttrs.TlbDynamicLb = stats.TlbDynamicLb
+		//intf.BondAttrs.MiiStatus = stats.MiiStatus
+
+	}
+	ipaddresses, err := netlink.AddrList(bli, netlink.FAMILY_V4)
+	if err != nil {
+		return err
+	}
+	if ipaddresses != nil {
+		intf.AddrList = ipaddresses
+	}
+
+	ipaddresses, err = netlink.AddrList(bli, netlink.FAMILY_V6)
+	if err != nil {
+		return err
+	}
+	if ipaddresses != nil {
+		for _, addr := range ipaddresses {
+			intf.AddrList = append(intf.AddrList, addr)
+		}
+	}
+
+	return nil
+}
+
+// NewDecoder creates and initializes a BondInterface as Decoder
+func NewDecoder(name string) *BondInterface {
+	intf := new(BondInterface)
+	intf.Name = name
+	return intf
+}

--- a/bonding/bonding.go
+++ b/bonding/bonding.go
@@ -43,7 +43,6 @@ type BondAttrs struct {
 	AdUserPortKey   int
 	AdActorSystem   net.HardwareAddr
 	TlbDynamicLb    int
-	//MiiStatus int
 }
 
 // Decode make BondInterface satisfy the mox.Decoder interface
@@ -106,8 +105,6 @@ func (intf *BondInterface) Decode() error {
 		intf.BondAttrs.AdUserPortKey = stats.AdUserPortKey
 		intf.BondAttrs.AdActorSystem = stats.AdActorSystem
 		intf.BondAttrs.TlbDynamicLb = stats.TlbDynamicLb
-		//intf.BondAttrs.MiiStatus = stats.MiiStatus
-
 	}
 	ipaddresses, err := netlink.AddrList(bli, netlink.FAMILY_V4)
 	if err != nil {

--- a/bonding/stats.go
+++ b/bonding/stats.go
@@ -1,0 +1,61 @@
+package bonding
+
+import (
+	"fmt"
+
+	"github.com/moxspec/moxspec/loglet"
+	"github.com/vishvananda/netlink"
+)
+
+var log *loglet.Logger
+
+func init() {
+	log = loglet.NewLogger("netlink")
+}
+
+// findBondSlaves returns slave devs of a bond master
+func findBondSlaves(index int) ([]string, error) {
+
+	var slaves []string
+
+	linklist, err := netlink.LinkList()
+	if err != nil {
+		return slaves, err
+	}
+
+	for _, link := range linklist {
+		if link.Attrs().MasterIndex == index {
+			slaves = append(slaves, link.Attrs().Name)
+		}
+	}
+
+	return slaves, nil
+}
+
+func GetBondDevices() []string {
+	var bonds []string
+
+	linklist, err := netlink.LinkList()
+	if err != nil {
+		log.Debugf("netlink.LinkList() failed: %s", err)
+		return bonds
+	}
+
+	for _, link := range linklist {
+		if link.Type() != "bond" {
+			continue
+		}
+		bonds = append(bonds, link.Attrs().Name)
+	}
+
+	return bonds
+}
+
+func getBondParameters(devlink netlink.Link) (*netlink.Bond, error) {
+
+	if parameters, ok := devlink.(*netlink.Bond); ok {
+		return parameters, nil
+	}
+	return nil, fmt.Errorf("%s is not a bonding device", devlink.Attrs().Name)
+
+}

--- a/cmd/mox/network.go
+++ b/cmd/mox/network.go
@@ -51,7 +51,6 @@ func shapeNetwork(r *model.Report, pcidevs *pci.Devices) {
 		c.BondAttrs.FailOverMac = bd.BondAttrs.FailOverMac.String()
 		c.BondAttrs.XmitHashPolicy = bd.BondAttrs.XmitHashPolicy.String()
 		c.BondAttrs.LacpRate = bd.BondAttrs.LacpRate.String()
-		//c.BondAttrs.MiiStatus = bd.BondAttrs.MiiStatus
 
 		for _, ipaddress := range bd.AddrList {
 			ipaddr := new(model.IPAddress)

--- a/cmd/mox/network.go
+++ b/cmd/mox/network.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net"
+
+	"github.com/moxspec/moxspec/bonding"
 	"github.com/moxspec/moxspec/eth"
 	"github.com/moxspec/moxspec/model"
 	"github.com/moxspec/moxspec/netlink"
@@ -11,7 +14,69 @@ import (
 func shapeNetwork(r *model.Report, pcidevs *pci.Devices) {
 	r.Network = new(model.NetworkReport)
 
+	var bondings []*model.BondInterface
 	var controllers []*model.EthController
+
+	for _, bond := range bonding.GetBondDevices() {
+		c := new(model.BondInterface)
+		c.Name = bond
+
+		bd := bonding.NewDecoder(bond)
+		err := bd.Decode()
+		if err != nil {
+			log.Debug(err)
+			bondings = append(bondings, c)
+			continue
+		}
+
+		c.Slaves = bd.Slaves
+
+		c.LinkAttrs.State = bd.LinkAttrs.OperState.String()
+		c.LinkAttrs.HWAddr = bd.LinkAttrs.HardwareAddr.String()
+		c.LinkAttrs.MTU = bd.LinkAttrs.MTU
+		c.LinkAttrs.TxQLen = bd.LinkAttrs.TxQLen
+
+		c.BondAttrs.Mode = bd.BondAttrs.Mode.String()
+		c.BondAttrs.ActiveSlave = bd.BondAttrs.ActiveSlave
+		c.BondAttrs.Miimon = bd.BondAttrs.Miimon
+		c.BondAttrs.UpDelay = bd.BondAttrs.UpDelay
+		c.BondAttrs.DownDelay = bd.BondAttrs.DownDelay
+		c.BondAttrs.UseCarrier = bd.BondAttrs.UseCarrier
+		c.BondAttrs.ArpInterval = bd.BondAttrs.ArpInterval
+		c.BondAttrs.ArpIpTargets = bd.BondAttrs.ArpIpTargets
+		c.BondAttrs.ArpValidate = bd.BondAttrs.ArpValidate.String()
+		c.BondAttrs.ArpAllTargets = bd.BondAttrs.ArpAllTargets.String()
+		c.BondAttrs.Primary = bd.BondAttrs.Primary
+		c.BondAttrs.PrimaryReselect = bd.BondAttrs.PrimaryReselect.String()
+		c.BondAttrs.FailOverMac = bd.BondAttrs.FailOverMac.String()
+		c.BondAttrs.XmitHashPolicy = bd.BondAttrs.XmitHashPolicy.String()
+		c.BondAttrs.LacpRate = bd.BondAttrs.LacpRate.String()
+		//c.BondAttrs.MiiStatus = bd.BondAttrs.MiiStatus
+
+		for _, ipaddress := range bd.AddrList {
+			ipaddr := new(model.IPAddress)
+			ipaddr.Addr = ipaddress.IP.String()
+
+			if ipaddress.IP.To4() == nil {
+				ipaddr.Version = 6
+			} else {
+				ipaddr.Version = 4
+			}
+
+			ipaddr.Netmask = net.IP(ipaddress.Mask).String()
+
+			ipaddr.MaskSize, _ = ipaddress.Mask.Size()
+
+			ipaddr.Broadcast = ipaddress.Broadcast.String()
+
+			ipaddr.Network = ipaddress.IPNet.String()
+
+			c.LinkAttrs.IPAddrs = append(c.LinkAttrs.IPAddrs, ipaddr)
+		}
+
+		bondings = append(bondings, c)
+	}
+
 	for _, ctl := range pcidevs.FilterByClass(pci.NetworkController) {
 		c := new(model.EthController)
 		c.PCIBaseSpec = *shapePCIDevice(ctl)
@@ -81,4 +146,5 @@ func shapeNetwork(r *model.Report, pcidevs *pci.Devices) {
 	}
 
 	r.Network.EthControllers = controllers
+	r.Network.BondInterfaces = bondings
 }

--- a/cmd/mox/show.go
+++ b/cmd/mox/show.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/moxspec/moxspec/model"
 )
@@ -395,6 +396,22 @@ func writeDownNetwork(r *model.Report, p *printer) {
 			sb.append(newIndentedBlock(ctl.DiagSummaries()))
 		}
 
+		s.block.append(sb)
+	}
+
+	if r.Network.BondInterfaces == nil {
+		p.append(s)
+		return
+	}
+	for _, ctl := range r.Network.BondInterfaces {
+		s.block.appendf(ctl.Summary())
+		sb := new(block)
+		sb.append(fmt.Sprintf("Link: %s, type bond, slaves %v, mode %s %s", ctl.Name, ctl.Slaves, ctl.BondAttrs.Mode, ctl.BondAttrs.XmitHashPolicy))
+		var iplist []string
+		for _, i := range ctl.LinkAttrs.IPAddrs {
+			iplist = append(iplist, fmt.Sprintf("%s/%d", i.Addr, i.MaskSize))
+		}
+		sb.append(fmt.Sprintf("Intf: %s, %s %s", ctl.Name, ctl.LinkAttrs.HWAddr, strings.Join(iplist, ", ")))
 		s.block.append(sb)
 	}
 	p.append(s)

--- a/model/bonding.go
+++ b/model/bonding.go
@@ -37,22 +37,6 @@ type BondAttrs struct {
 	FailOverMac     string   `json:"fail_over_mac,omitempty"`
 	XmitHashPolicy  string   `json:"xmit_hash_policy,omitempty"`
 	LacpRate        string   `json:"lacp_rate,omitempty"`
-
-	// We don't currently need the following values, but netlink provides them
-	// Just put here as a reference
-	// MiiStatus       int      `json:"mii_status,omitempty"`
-	// ResendIgmp      int
-	// NumPeerNotif    int
-	// AllSlavesActive int
-	// MinLinks        int
-	// LpInterval      int
-	// PacketsPerSlave int
-	// AdSelect        BondAdSelect
-	// AdInfo          *BondAdInfo
-	// AdActorSysPrio  int
-	// AdUserPortKey   int
-	// AdActorSystem   net.HardwareAddr
-	// TlbDynamicLb    int
 }
 
 // Summary returns summarized string

--- a/model/bonding.go
+++ b/model/bonding.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"fmt"
+	"net"
+)
+
+// BondInterface represents a bonding device
+type BondInterface struct {
+	Name      string    `json:"name"`
+	Slaves    []string  `json:"slaves,omitempty"`
+	LinkAttrs LinkAttrs `json:"link_attrs,omitempty"`
+	BondAttrs BondAttrs `json:"bond_attrs,omitempty"`
+}
+
+type LinkAttrs struct {
+	State   string       `json:"state,omitempty"`
+	HWAddr  string       `json:"hwaddr,omitempty"`
+	MTU     int          `json:"mtu"`
+	TxQLen  int          `json:"tx_qlen"`
+	IPAddrs []*IPAddress `json:"ipaddrs,omitempty"`
+}
+
+type BondAttrs struct {
+	Mode            string   `json:"mode,omitempty"`
+	ActiveSlave     string   `json:"active_slaves,omitempty"`
+	Miimon          int      `json:"miimon,omitempty"`
+	UpDelay         int      `json:"updelay,omitempty"`
+	DownDelay       int      `json:"downdelay,omitempty"`
+	UseCarrier      int      `json:"use_carrier,omitempty"`
+	ArpInterval     int      `json:"arp_interval,omitempty"`
+	ArpIpTargets    []net.IP `json:"arp_ip_target,omitempty"`
+	ArpValidate     string   `json:"arp_validate,omitempty"`
+	ArpAllTargets   string   `json:"arp_all_targets,omitempty"`
+	Primary         string   `json:"primary,omitempty"`
+	PrimaryReselect string   `json:"primary_reselect,omitempty"`
+	FailOverMac     string   `json:"fail_over_mac,omitempty"`
+	XmitHashPolicy  string   `json:"xmit_hash_policy,omitempty"`
+	LacpRate        string   `json:"lacp_rate,omitempty"`
+
+	// We don't currently need the following values, but netlink provides them
+	// Just put here as a reference
+	// MiiStatus       int      `json:"mii_status,omitempty"`
+	// ResendIgmp      int
+	// NumPeerNotif    int
+	// AllSlavesActive int
+	// MinLinks        int
+	// LpInterval      int
+	// PacketsPerSlave int
+	// AdSelect        BondAdSelect
+	// AdInfo          *BondAdInfo
+	// AdActorSysPrio  int
+	// AdUserPortKey   int
+	// AdActorSystem   net.HardwareAddr
+	// TlbDynamicLb    int
+}
+
+// Summary returns summarized string
+func (n BondInterface) Summary() string {
+	return fmt.Sprintf("Bond Device %s", n.Name)
+}

--- a/model/network.go
+++ b/model/network.go
@@ -8,6 +8,7 @@ import (
 // NetworkReport represents a network report
 type NetworkReport struct {
 	EthControllers []*EthController `json:"ethControllers,omitempty"`
+	BondInterfaces []*BondInterface `json:"bondInterfaces,omitempty"`
 }
 
 // EthController represents an ethernet controller


### PR DESCRIPTION
1. I added an extra dependency github.com/vishvananda/netlink, instead of using github.com/moxspec/moxspec/netlink, because bonding's netlink data is nested and need a lot of unsafe code to unserialize. 
2. I only added some of the bonding data that I think is essential for the most common bonding type 802.3ad, instead of all the data netlink provides, because the other data are either not suitable for 802.3ad, and I cannot test them, or a little complex to parse. 


> show bonding device's parameters and network info
> 
> We only need some but not all of the data that netlink provides, some of
> the data are ignored and won't be put into the json output.
> 
> We use github.com/vishvananda/netlink instead of
> github.com/moxspec/moxspec/netlink, because bonding's netlink data is
> nested and a little bit complex to parse. Golang's syscall module
> doesn't provide any public functions to parse nested netlink data. To
> use the latter module I have to copy and modify many private functions
> from the syscall module, which makes the code pretty large.